### PR TITLE
Prevent numbered suffix when filename unchanged

### DIFF
--- a/VideoSort.py
+++ b/VideoSort.py
@@ -1189,6 +1189,11 @@ def construct_path(filename):
     if verbose:
         print('destination path: %s' % new_path)
 
+    if filename.upper() == new_path.upper():
+        if verbose:
+            print('Destination path equals filename  - return None')
+        return None
+
     return new_path
 
 # Flag indicating that anything was moved. Cleanup possible.


### PR DESCRIPTION
When the destination path is the same as the original filename, the file would be renamed with a numbered suffix (ex. (2) ) added to the filename.

This fix will prevent the file from being renamed when the destination filename is the same as the original filename.

Originally discussed here ...
https://forum.nzbget.net/viewtopic.php?f=8&t=840&p=17107#p17108

Also fixes this issue(?)
https://github.com/nzbget/VideoSort/issues/13