### PR TITLE
fix: DatedFormat is missing Episode related specifiers

### DIFF
--- a/VideoSort.py
+++ b/VideoSort.py
@@ -188,6 +188,8 @@
 # %sn, %s.n, %s_n - show name with words separated with spaces, dots
 #                   or underscores (case-adjusted);
 # %sN, %s.N, %s_N - show name (original letter case);
+# %en, %e.n, %e_n - episode name (case-adjusted);
+# %eN, %e.N, %e_N - episode name (original letter case);
 # %y              - year;
 # %decade         - two-digits decade (90, 00, 10);
 # %0decade        - four-digits decade (1990, 2000, 2010).
@@ -197,7 +199,7 @@
 # %0d              - two-digits day (01-31).
 #
 # For a list of common specifiers see option <MoviesFormat>.
-#DatedFormat=%sn/%sn - %y-%0m-%0d
+#DatedFormat=%sn/%sn - %en - %y-%0m-%0d
 
 # Formatting rules for other TV shows.
 #
@@ -920,6 +922,28 @@ def add_dated_mapping(guess, mapping):
     mapping.append(('%sN', show_name))
     mapping.append(('%s.N', show_name_two))
     mapping.append(('%s_N', show_name_three))
+
+    # Some older code at this point stated:
+    # "Guessit doesn't provide episode names for dated tv shows"
+    # but was referring to the invalid field '%desc'
+    # In my researches I couldn't find such a case, but just to be sure
+    ep_title = guess.get('episode_title')
+    if ep_title:
+        ep_tname, ep_tname_two, ep_tname_three = get_titles(ep_title, True)
+        ep_name, ep_name_two, ep_name_three = get_titles(ep_title, False)
+        mapping.append(('%en', ep_tname))
+        mapping.append(('%e.n', ep_tname_two))
+        mapping.append(('%e_n', ep_tname_three))
+        mapping.append(('%eN', ep_name))
+        mapping.append(('%e.N', ep_name_two))
+        mapping.append(('%e_N', ep_name_three))
+    else:
+        mapping.append(('%en', ''))
+        mapping.append(('%e.n', ''))
+        mapping.append(('%e_n', ''))
+        mapping.append(('%eN', ''))
+        mapping.append(('%e.N', ''))
+        mapping.append(('%e_N', ''))
 
     # date
     date = guess.get('date')

--- a/testdata.json
+++ b/testdata.json
@@ -144,21 +144,21 @@
   },
   {
     "id": "dated-case-correct",
-    "INPUTFILE": "the.daily.show.2013.06.27.Tom.Goldstein.HDTV.x264-FQM.mkv",
-    "OUTPUTFILE": "/dated/2013-06/The Daily Show - 2013-6-27.mkv",
-    "NZBPO_DATEDFORMAT": "%y-%0m/%sn - %y-%m-%0d.%ext"
+    "INPUTFILE": "the.daily.show.2013.6.2.tom.goldstein.HDTV.x264-FQM.mkv",
+    "OUTPUTFILE": "/dated/2013-06/The Daily Show - Tom Goldstein - 2013-6-02.mkv",
+    "NZBPO_DATEDFORMAT": "%y-%0m/%sn - %en - %y-%m-%0d.%ext"
   },
   {
     "id": "dated-case-correct-_",
-    "INPUTFILE": "Real.Time.With.Bill.Maher.2014.10.31.720p.HDTV.x264-BATV.mkv",
-    "OUTPUTFILE": "/dated/2014-10/Real_Time_With_Bill_Maher - 2014-10-31.mkv",
-    "NZBPO_DATEDFORMAT": "%y-%0m/%s_n - %y-%m-%0d.%ext"
+    "INPUTFILE": "the.daily.show.2013.6.2.tom.goldstein.HDTV.x264-FQM.mkv",
+    "OUTPUTFILE": "/dated/2013-06/The_Daily_Show - Tom_Goldstein - 2013-6-02.mkv",
+    "NZBPO_DATEDFORMAT": "%y-%0m/%s_n - %e_n - %y-%m-%0d.%ext"
   },
   {
     "id": "dated-case-preserve",
-    "INPUTFILE": "the.daily.show.2013.06.27.Tom.Goldstein.HDTV.x264-FQM.mkv",
-    "OUTPUTFILE": "/dated/the daily show - 2013-6-27.mkv",
-    "NZBPO_DATEDFORMAT": "%sN - %y-%m-%0d.%ext"
+    "INPUTFILE": "the.daily.show.2013.6.2.tom.goldstein.HDTV.x264-FQM.mkv",
+    "OUTPUTFILE": "/dated/2013-06/the daily show - tom goldstein - 2013-6-02.mkv",
+    "NZBPO_DATEDFORMAT": "%y-%0m/%sN - %eN - %y-%m-%0d.%ext"
   },
   {
     "id": "multi-1",


### PR DESCRIPTION
Without episode information, only the date is available to differentiate
the episodes, which is missing half of the available information.

Existing code from SeriesFormat was reused, the existing test cases for
DatedFormat just needed slight adjustments. But the opportunity was
taken, to unify the INPUTFILE for better readability.

Documentation is updated, the default format extended with episode name.

Closes #51