### PR TITLE
Fixed crash when encountering arrays in mapping

### DIFF
--- a/VideoSort.py
+++ b/VideoSort.py
@@ -607,7 +607,7 @@ def path_subst(path, mapping):
                     break
         newpath.append(result)
         n += 1
-    return ''.join(newpath)
+    return ''.join(map(lambda x: '.'.join(x) if isinstance(x, list) else str(x), newpath))
 
 def get_titles(name, titleing=False):
     '''

--- a/testdata.json
+++ b/testdata.json
@@ -185,5 +185,11 @@
     "INPUTFILE": "Fargo.1996.REMASTERED.BluRay.720p.H264-20-40.mp4",
     "OUTPUTFILE": "/movies/Fargo (1996).mp4",
     "NZBPO_MOVIESFORMAT": "%t (%y).%ext"
+  },
+  {
+    "id": "multi-cat",
+    "INPUTFILE": "Bohemian.Rhapsody.2018.REMUX.2160p.(10bit).BluRay.UHD.HDR.HEVC.TrueHD.DTS-HD.MA.7.1-LEGi0N.mkv",
+    "OUTPUTFILE": "/movies/Bohemian Rhapsody (2018) BluRay-4K h265 7.1 TrueHD.DTS.mkv",
+    "NZBPO_MOVIESFORMAT": "/movies/%t (%y) %qf-%qss %qvc %qah %qac.%ext"
   }
 ]

--- a/testsort.py
+++ b/testsort.py
@@ -92,7 +92,7 @@ def run_test(testobj):
 	shutil.rmtree(test_dir, True)
 	os.mkdir(test_dir)
 	dir_name, file_name = os.path.split(input_file)
-	if dir_name <> '':
+	if dir_name != '':
 		os.mkdir(test_dir + '/' + dir_name)
 	full_file_name = test_dir + '/' + input_file
 	out_file = open(full_file_name, 'w')
@@ -112,13 +112,13 @@ def run_test(testobj):
 	dest = ''
 
 	if ret == 93:
-		for line in out.split('\n'):
-			if line.startswith('destination path: '):
-				line = line[len('destination path: '):]
-				if line.startswith(root_dir):
-					line = line[len(root_dir):]
-				dest = line.replace('\\', '/')
-		success = dest == output_file and output_file <> ''
+		for line in out.split(b'\n'):
+			if line.startswith(b'destination path: '):
+				line = line[len(b'destination path: '):]
+				if line.startswith(root_dir.encode()):
+					line = line[len(root_dir.encode()):]
+				dest = line.replace(b'\\', b'/').decode()
+		success = dest == output_file and output_file != ''
 
 	if success:
 		print('%s: SUCCESS' % testobj['id'])


### PR DESCRIPTION
In cases where the input filename was parsed so that multiple valid matches occurred for categories (%qac containing ["TrueHD", "DTS"] for the example in the added test case), VideoSort would throw an error that looked like this:

`VideoSort: TypeError: sequence item 14: expected str instance, list found  
VideoSort: return ''.join(newpath)  
VideoSort: File "VideoSort.py", line 610, in path_subst  
VideoSort: path = path_subst(sorter, mapping)  
VideoSort: File "VideoSort.py", line 1214, in construct_path  
VideoSort: new_path = construct_path(old_path)  
VideoSort: File "VideoSort.py", line 1292, in <module>  
VideoSort: Traceback (most recent call last):`